### PR TITLE
change configuration generator to remove leading zero in month

### DIFF
--- a/autolj.sh
+++ b/autolj.sh
@@ -135,7 +135,7 @@ doctypes='pdf'
 save_dir='\$HOME/linuxjournal/issues'
 
 # File name.
-save_file='LJ-\$(printf %03d \${inum})-\$year-\$(printf %02d \${month}).\${doc}'
+save_file='LJ-\$(printf %03d \${inum})-\$year-\$(printf %02d \${month#0}).\${doc}'
 
 # Notification message (also eval'd).
 notify_msg='The \$(date +%B --date \${month}/1) \${year} Linux Journal \${doc^^}\\\\nhas been downloaded.'


### PR DESCRIPTION
I ran into this problem when the autolj script ran today:

autolj.sh: line 73: printf: 08: invalid octal number

I fixed this by editing ~/.config/autolj.cfg and changing line 26 to say:
save_file='LJ-$(printf %03d ${inum})-$year-$(printf %02d ${month#0}).${doc}'
(Note the '#0' after 'month'.)

The reason for this is here:
https://stackoverflow.com/questions/8078167/bizarre-issue-with-printf-in-bash-script09-and-08-are-invalid-numbers-07

Individual users will still need to modify their existing .cfg file, but new users should init with a config file that works in August and September.